### PR TITLE
chore: correct the project url in cliff config

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -46,7 +46,7 @@ footer = """
 trim = true
 # postprocessors
 postprocessors = [
-    { pattern = '\$REPO', replace = "https://github.com/tyrchen/geektime-rust-live-coding" }, # replace repository URL
+    { pattern = '\$REPO', replace = "https://github.com/chenjun-arthur/rcli" }, # replace repository URL
 ]
 
 [git]


### PR DESCRIPTION
Fix the github url in cliff.toml